### PR TITLE
Active Markdown par défaut

### DIFF
--- a/wiki.php
+++ b/wiki.php
@@ -1,1 +1,3 @@
 <?php
+
+$wakkaConfig['use_md'] = isset($wakkaConfig['use_md']) ? $wakkaConfig['use_md'] : true;


### PR DESCRIPTION
**Pourquoi ?** Parce qu'en activant l'extension sur la Ferme, on a Markdown sans modifier de fichier de configuration.

Sinon l'installation se fait sans pouvoir utiliser la fonctionnalité (alors que l'extension est active).

Si on ne veut pas de Markdown, supprimer/désactiver l'extension.